### PR TITLE
Fixed bug where user could promote to the team captain position to someone who was no longer on team

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,8 +49,11 @@ class UsersController < ApplicationController
   # rubocop:enable MethodLength
 
   def promote
-    @team.promote(params[:user_id])
-    redirect_to @team, notice: I18n.t('teams.promoted_captain')
+    if @team.promote(params[:user_id])
+      redirect_to @team, notice: I18n.t('teams.promoted_captain')
+    else
+      redirect_to @team, alert: I18n.t('teams.cannot_promote_captain')
+    end
   end
 
   private

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -104,7 +104,9 @@ class Team < ActiveRecord::Base
   end
 
   def promote(user_id)
-    update_attributes(team_captain: users.find_by(id: user_id))
+    new_captain = users.find_by(id: user_id)
+    update_attributes(team_captain: new_captain) if new_captain
+    !new_captain.nil?
   end
 
   def update_eligibility

--- a/config/locales/registration.en.yml
+++ b/config/locales/registration.en.yml
@@ -40,6 +40,7 @@ en:
     invalid_permissions: 'You must first be a member of a team in order to view it.'
     captain_must_promote: 'You must promote another member of your team to captain before leaving.'
     promoted_captain: 'A new team captain has been promoted.'
+    cannot_promote_captain: 'You cannot promote this user to be the captain.'
     must_be_team_captain: 'You must be the team captain to perform this action.'
     must_be_on_team: 'You must be on a team to view other teams.'
     in_top_ten: 'This team is currently locked since it is in the top ten for its division.'

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -66,6 +66,15 @@ class UsersControllerTest < ActionController::TestCase
     assert_equal I18n.t('teams.promoted_captain'), flash[:notice]
   end
 
+  test 'captain is not promoted' do
+    sign_in users(:full_team_user_one)
+    team = users(:full_team_user_one).team
+    get :promote, params: { user_id: users(:user_five), team_id: team } # User 5 is not on full_team
+    assert :success
+    assert_redirected_to team
+    assert_equal I18n.t('teams.cannot_promote_captain'), flash[:alert]
+  end
+
   test 'user cannot promote' do
     sign_in users(:full_team_user_five)
     team = users(:full_team_user_five).team


### PR DESCRIPTION
There was no validation on the user promote method, added validation to make sure that the user we are promoting actually exists on the team before promoting them.