### PR TITLE
Scope team query properly on join team page

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -36,7 +36,7 @@ class Team < ApplicationRecord
 
   scope :filter_affiliation, lambda { |query|
     return nil if query.blank?
-    search_by(query, 'affiliation')
+    search_by(query, 'teams.affiliation')
   }
 
   scope :location, lambda { |query|


### PR DESCRIPTION
When the filter attempts to filter on both the team and location the scope gets mixed up and affiliation becomes ambiguous since both user and team have an affiliation. This fixes the issue by specifying that the query should be scoped to the team. Closes #70