### PR TITLE
Add passenger for development as well as production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'jquery-rails'
 gem 'obscenity'
 gem 'paper_trail'
 gem 'paperclip'
+gem 'passenger', require: 'phusion_passenger/rack_handler'
 gem 'pg'
 gem 'prawn'
 gem 'rails', '~> 5.0.0'
@@ -51,6 +52,5 @@ group :assets do
 end
 
 group :production do
-  gem 'passenger'
   gem 'scout_apm'
 end


### PR DESCRIPTION
Switching to passenger instead of WEBrick even though nothing bad has happened on this project *yet* from us using two different web servers for development and production. We have begun to get into the kind of stuff where discrepancies begin to appear, such as PDF generation.

We should watch this PR pretty close when we actually merge it. In order to get it to work I had to add a require line that was not there before. I am not sure what that specific line does when it is included for the production environment. Hopefully it will not cause any problems.