### PR TITLE
Added VPN Certificate download through S3 to the scoreboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 
 # Ignore sensitive files
 .gmail_env
+.dev_vars
 
 # Ignore simplecov output.
 coverage

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 ruby '2.3.4'
 
 gem 'awesome_nested_fields'
+gem 'aws-sdk-s3'
 gem 'bluecloth'
 gem 'bootstrap-sass', '~> 2.3.2.2'
 gem 'chartkick'
@@ -30,7 +31,7 @@ gem 'sentry-raven'
 gem 'letter_opener', group: :development
 
 group :development, :test do
-  gem 'pry'
+  gem 'pry-remote'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,19 @@ GEM
     ast (2.3.0)
     awesome_nested_fields (0.6.4)
       rails (>= 3.0.0)
+    aws-partitions (1.20.0)
+    aws-sdk-core (3.3.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.1.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.2.0)
+      aws-sdk-core (~> 3)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.2)
     bcrypt (3.1.11)
     bluecloth (2.2.0)
     bootstrap-sass (2.3.2.2)
@@ -57,7 +70,7 @@ GEM
     climate_control (0.2.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
-    coderay (1.1.1)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -111,6 +124,7 @@ GEM
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
     i18n (0.8.4)
+    jmespath (1.3.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -178,6 +192,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
     public_suffix (2.0.5)
     rack (2.0.3)
     rack-pjax (1.0.0)
@@ -297,6 +314,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_nested_fields
+  aws-sdk-s3
   bluecloth
   bootstrap-sass (~> 2.3.2.2)
   brakeman
@@ -319,7 +337,7 @@ DEPENDENCIES
   passenger
   pg
   prawn
-  pry
+  pry-remote
   rails (~> 5.0.0)
   rails-controller-testing
   rails_admin
@@ -335,4 +353,4 @@ RUBY VERSION
    ruby 2.3.4p301
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,6 +46,16 @@ class UsersController < ApplicationController
     end
   end
 
+  def download_vpn_cert
+    certificate_url = current_user.vpn_cert_url
+    if certificate_url
+      current_user.update_attributes(vpn_cert_downloaded: true)
+      redirect_to certificate_url
+    else
+      redirect_back fallback_location: user_root_path, alert: I18n.t('users.certificate_not_ready')
+    end
+  end
+
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable MethodLength
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -92,6 +92,10 @@
         .alert.alert-error
           %a.close{"data-dismiss" => "alert", :href => "#"} ×
           = alert
+      - if content_for? :vpn_cert_download
+        = yield :vpn_cert_download
+      - elsif !current_user&.vpn_cert_downloaded? && current_user&.vpn_cert_available?
+        = render partial: "users/vpn_cert_alert"
     .container
       = yield
   %footer#page-footer.well.footer

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -1,5 +1,8 @@
 - content_for :header do
   See your Team
+- content_for :vpn_cert_download do
+  - if current_user&.vpn_cert_available?
+    = render partial: "users/vpn_cert_alert"
 %h2 #{@team.display_name} - Team Information
 %h3 Affiliation: #{@team.affiliation}
 %table.table.table-condensed.table-striped

--- a/app/views/users/_vpn_cert_alert.html.haml
+++ b/app/views/users/_vpn_cert_alert.html.haml
@@ -1,0 +1,9 @@
+.alert.alert-success.alert-block.alert-dismissible
+  %a.close{"data-dismiss" => "alert", :href => "#"} ×
+  %h4="VPN Certificate Available!"
+  The VPN certificate required for connecting to our infrastructure during the game is now
+  = succeed "." do
+    = link_to "available for download", download_vpn_cert_users_path
+  Instructions for connecting can be found in our
+  = succeed "." do
+    = link_to 'video library', 'http://mitrecyberacademy.org/learn/play/'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,4 +44,8 @@ Rails.application.configure do
 
   # Set default URL for mailer to mimic production
   config.action_mailer.default_url_options = { host: 'test.mitrecyberacademy.org' }
+
+  ENV['S3_KEY'] = 'fakekey'
+  ENV['S3_SECRET'] = 'fakesecret'
+  ENV['S3_BUCKET'] = 'ctfbucket'
 end

--- a/config/initializers/s3_initializer.rb
+++ b/config/initializers/s3_initializer.rb
@@ -1,0 +1,3 @@
+# Load up the S3 connection during initialization so that it will be ready to use
+# once the app is loaded.
+VpnModule::S3Certificates.instance

--- a/config/locales/registration.en.yml
+++ b/config/locales/registration.en.yml
@@ -71,5 +71,6 @@ en:
     must_be_on_team: 'You must be on a team to submit a flag.'
   users:
     login_required: 'You must login in order to perform this action.'
+    certificate_not_ready: 'Your VPN Certificate is not yet ready for download, please try again in a few minutes.'
   admin:
     should_not_do_action: 'Admins should use the Rails Admin console to perform administrative actions.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ CtfRegistration::Application.routes.draw do
 
   resource :users, only: [] do
     get :join_team, on: :member
+    get :download_vpn_cert
   end
 
   # Saying resources :users do causes all routes for the team to be generated.

--- a/db/migrate/20170908134724_add_vpn_cert_downloaded_to_users.rb
+++ b/db/migrate/20170908134724_add_vpn_cert_downloaded_to_users.rb
@@ -1,0 +1,5 @@
+class AddVpnCertDownloadedToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :vpn_cert_downloaded, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170706132149) do
+ActiveRecord::Schema.define(version: 20170908134724) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -186,6 +186,7 @@ ActiveRecord::Schema.define(version: 20170706132149) do
     t.float    "longitude"
     t.string   "country"
     t.datetime "messages_stamp",                   default: '1970-01-01 00:00:00', null: false
+    t.boolean  "vpn_cert_downloaded",              default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree

--- a/lib/tasks/scoreboard.rake
+++ b/lib/tasks/scoreboard.rake
@@ -3,6 +3,6 @@
 namespace :scoreboard do
   desc 'Recreates key file requests for all registered users'
   task create_key_requests: :environment do
-    User.all.each(&:create_vpn_key_request)
+    User.all.each(&:create_vpn_cert_request)
   end
 end

--- a/lib/vpn_module.rb
+++ b/lib/vpn_module.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'singleton'
+
+module VpnModule
+  class S3Certificates
+    include Singleton
+
+    @bucket_connection = nil
+
+    def initialize
+      credential_stub = Aws::Credentials.new(ENV['S3_KEY'], ENV['S3_SECRET'])
+      client_stub = Aws::S3::Client.new(
+        region: 'us-east-1',
+        credentials: credential_stub,
+        stub_responses: Rails.env.test?
+      )
+      s3 = Aws::S3::Resource.new(client: client_stub)
+      @bucket_connection = s3.bucket(ENV['S3_BUCKET'])
+    end
+
+    def find_or_create_cert_for(filename)
+      certificate_bundle = @bucket_connection.object("#{filename}.zip")
+      return certificate_bundle.presigned_url(:get, expires_in: 10.minutes.to_i) if certificate_bundle.exists?
+      create_certificate_for(filename)
+      nil
+    end
+
+    def cert_ready_for?(filename)
+      return true if bucket_file_exists?("#{filename}.zip")
+      create_certificate_for(filename) unless bucket_file_exists?(filename)
+      false
+    end
+
+    def bucket_file_exists?(filename)
+      @bucket_connection.object(filename).exists?
+    end
+
+    def create_certificate_for(filename)
+      @bucket_connection.object(filename).put
+    end
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -97,4 +97,12 @@ class UsersControllerTest < ActionController::TestCase
     assert_redirected_to @controller.user_root_path
     assert_equal I18n.t('teams.in_top_ten'), flash[:alert]
   end
+
+  test 'vpn_cert_downloaded is properly updated when the user downloads their certificate' do
+    user = users(:full_team_user_one)
+    sign_in user
+    get :download_vpn_cert
+    assert_redirected_to %r(\Ahttps://.*\.s3\.amazonaws\.com)
+    assert user.reload.vpn_cert_downloaded
+  end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -15,6 +15,10 @@ user_one:
   confirmed_at: <%= Time.now %>
   team: team_one
 
+admin_user:
+  email: mitrectf+admin@gmail.com
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'TestPassword123') %>
+
 # User with every possible piece of information provided except team
 user_two:
   full_name: User two

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -93,9 +93,28 @@ class UserTest < ActiveSupport::TestCase
     assert_equal(false, user_on_team.can_remove?(another_user))
   end
 
-  test 'key file name' do
-    key_file_name = 'mitrectfuse' + users(:user_one).id.to_s
-    assert_equal key_file_name, users(:user_one).key_file_name
+  test 'cert file name is property created' do
+    cert_file_name = users(:user_one).full_name.tr('^A-Za-z', '')[0..10] + users(:user_one).id.to_s
+    assert_equal cert_file_name, users(:user_one).vpn_cert_file_name
+  end
+
+  test 'admin cert filename is not broken if the admin has no name on file' do
+    admin = users(:admin_user)
+    admin.save
+    assert_equal admin.id.to_s, admin.vpn_cert_file_name
+  end
+
+  test 'users certificate is properly created' do
+    user = users(:user_one)
+    user.save
+    assert user.vpn_cert_request_created?
+    # The VPN certificate creation is all handled by the VPN server, here we workaround
+    # the fact that there is no VPN server in the test environment by saving the user and
+    # then calling the certificate creation method with the .zip extension. This will trigger
+    # the code to believe that the VPN server responded to the certificate request, however
+    # the "certificate" that is created is simply going to be an empty file
+    VpnModule::S3Certificates.instance.create_certificate_for("#{user.vpn_cert_file_name}.zip")
+    assert_not_nil user.vpn_cert_url
   end
 
   test 'users country is calculated on save' do


### PR DESCRIPTION
This requires the VPN server to be able to download the certificate requests off of S3 and then upload the zip files to S3.