### PR TITLE
Update ranking email to be more lenient on 2nd-10th place teams

### DIFF
--- a/app/views/user_mailer/ranking.html.haml
+++ b/app/views/user_mailer/ranking.html.haml
@@ -12,8 +12,8 @@
 - elsif @rank <= 10
   %p
     Because you finished in the top ten, we are requesting your resume and transcript. If you’re interested, please
-    email #{link_to 'ctf@mitre.org', 'mailto:ctf@mitre.org'} with your official college, university, or high school
-    transcript AND an up-to-date resume.
+    email #{link_to 'ctf@mitre.org', 'mailto:ctf@mitre.org'} with your official or unofficial college, university, or 
+    high school transcript AND an up-to-date resume.
 - if @rank <= 10
   %p
     While this competition was open to professional and government participants as part of cyber training, only


### PR DESCRIPTION
Currently we ask the 2nd-10th place teams for official transcripts which is a lot of work considering we don't really need an official transcript from them. Instead I think we should clarify that we will accept unofficial transcripts for the 2nd-10th place teams.